### PR TITLE
refactored so that all apiwrapper methods take only kwargs as args

### DIFF
--- a/ApiWrapper/groups.py
+++ b/ApiWrapper/groups.py
@@ -30,8 +30,13 @@ class Groups:
         url = self.URL_BASE + '/groups/former' + self.TOKEN_QUERY_STRING
         return create_response(url)
 
-    def getGroup(self, id):
+    # def getGroup(self, id):
+    def getGroup(self, **kwargs):
         ''' Gets a single group by its id'''
+        id = 0
+        for key, value in kwargs.items():
+            if key == 'id':
+                id = value
         url = self.URL_BASE + '/groups/' + str(id) + self.TOKEN_QUERY_STRING
         print(url)
         return create_response(url)
@@ -62,7 +67,8 @@ class Groups:
         else:
             return 'No valid name parameter provided'
 
-    def updateGroup(self, id, **kwargs):
+    # def updateGroup(self, id, **kwargs):
+    def updateGroup(self, **kwargs):
         ''' Updates specified group
             HTTP POST
             Params
@@ -75,8 +81,11 @@ class Groups:
             Returns POST response
         '''
         load = {}
+        id = 0
         for key, value in kwargs.items():
-            if key == 'name':
+            if key == 'id':
+                id = value
+            elif key == 'name':
                 load['name'] = value
             elif key == 'description':
                 load['description'] = value
@@ -88,11 +97,15 @@ class Groups:
         r = requests.post(url, json = load)
         return parse_response_from_json(r)
 
-    def destroyGroup(self, id):
+    def destroyGroup(self, **kwargs):
         ''' Destroys specified group
             Only availabe to groups creator
             HTTP POST
             Returns POST response'''
+        id = 0
+        for key, value in kwargs.items():
+            if key  == 'id':
+                id = value
         url = self.URL_BASE + '/groups/' + str(id) + '/destroy' + self.TOKEN_QUERY_STRING
         r = requests.post(url)
         return parse_response_from_json(r)

--- a/ApiWrapper/members.py
+++ b/ApiWrapper/members.py
@@ -44,23 +44,34 @@ class Members:
         r = requests.post(url, json = load)
         return self.parse_response_from_json(r)
 
-    def remove(self, membership_id):
+    def remove(self, **kwargs):
         '''
         Remove a member from a grup
         NOTE: Creator cannot be removed
         Params
             membership_id: string — Please note that this isn't the same as the user ID. In the members key in the group JSON, this is the id value, not the user_id.
         '''
+        membership_id = 0
+        for key, value in kwargs.items():
+            if key == 'membership_id':
+                membership_id = value
+        
         url = self.URL_BASE + '/groups/' + str(self.groupId) + '/members/' + str(membership_id) + '/remove' + self.TOKEN_QUERY_STRING
         r = requests.post(url)
         return self.parse_response_from_json(r)
     
-    def update(self, nickname):
+    # def update(self, nickname):
+    def update(self, **kwargs):
         '''
         Update YOUR nickname in a group. The nickname must be between 1 and 50 chars
         Params
             nickname: string - YOUR new nickname
         '''
+        nickname = ''
+        for key, value in kwargs.items():
+            if key == 'nickname':
+                nickname = value
+
         load = {}
         load['membership'] =  {'nickname': nickname}
         url = self.URL_BASE + '/groups/' + str(self.groupId) + '/memberships/update' + self.TOKEN_QUERY_STRING

--- a/ApiWrapper/messages.py
+++ b/ApiWrapper/messages.py
@@ -98,7 +98,12 @@ class Messages:
         r = requests.post(url, json = load)
         return self.parse_response_from_json(r)
 
-    def like(self, message_id):
+    # def like(self, message_id):
+    def like(self, **kwargs):
+        message_id = 0
+        for key, value in kwargs.items():
+            if key == 'message_id':
+                message_id = value
         url = self.URL_BASE + '/messages/' + str(self.groupId) + '/' + str(message_id) + '/like' + self.TOKEN_QUERY_STRING
         r = requests.post(url)
         return self.parse_response_from_json(r)


### PR DESCRIPTION
refactored all the apiwrapper methods to take only kwargs.  This is to simplify GroupmeClient's api.